### PR TITLE
fix: harden self-healing workflow permissions

### DIFF
--- a/.github/workflows/self_healing.yml
+++ b/.github/workflows/self_healing.yml
@@ -6,7 +6,7 @@ on:
     types: [completed]
 
 permissions:
-  contents: write
+  contents: read
   pull-requests: write
   issues: write
 
@@ -28,7 +28,5 @@ jobs:
           prompt: |
             The CI workflow failed.
             Analyze likely root causes and propose a minimal fix.
-            If a deterministic safe fix is obvious, commit the fix to
-            branch ${{ github.event.workflow_run.head_branch }}.
-            Otherwise, open an issue with analysis and a remediation plan.
+            Open an issue with analysis and a remediation plan.
           include_commit_log: true


### PR DESCRIPTION
This PR hardens the security of the self-healing workflow by removing write access to the repository contents and updating the agent instructions to report findings via issues rather than attempting to commit code directly. This mitigates risks associated with automated code changes and ensures safer handling of CI failures.

---
*PR created automatically by Jules for task [13755485734993368201](https://jules.google.com/task/13755485734993368201) started by @itsimonfredlingjack*