### PR TITLE
Fix security regressions in self-healing workflow

### DIFF
--- a/.github/workflows/self_healing.yml
+++ b/.github/workflows/self_healing.yml
@@ -6,7 +6,7 @@ on:
     types: [completed]
 
 permissions:
-  contents: write
+  contents: read
   pull-requests: write
   issues: write
 
@@ -41,8 +41,6 @@ jobs:
           jules_api_key: ${{ secrets.JULES_API_KEY }}
           prompt: |
             The CI workflow failed.
-            Analyze likely root causes and propose a minimal fix.
-            If a deterministic safe fix is obvious, commit the fix to
-            branch ${{ github.event.workflow_run.head_branch }}.
-            Otherwise, open an issue with analysis and a remediation plan.
+            Analyze likely root causes and open an issue with the analysis and a remediation plan.
+            Do not commit code directly.
           include_commit_log: true


### PR DESCRIPTION
Secured the self-healing workflow by removing write access to repository contents and instructing the agent to open issues for remediation instead of committing code directly. This prevents potential infinite CI loops and ensures all changes go through proper review channels.

---
*PR created automatically by Jules for task [2251720328357594317](https://jules.google.com/task/2251720328357594317) started by @itsimonfredlingjack*