### PR TITLE
docs: add PR review findings

### DIFF
--- a/PR_REVIEW.md
+++ b/PR_REVIEW.md
@@ -1,0 +1,46 @@
+# PR Review
+
+## 1. Security Regressions
+
+### CRITICAL: Dangerous Permissions in Self-Healing Workflow
+**File:** `.github/workflows/self_healing.yml`
+**Issue:** The `heal-failure` job has `contents: write` permissions and runs on `workflow_run` (triggered by CI completion).
+**Risk:** This workflow runs in the context of the base repository (privileged) but checks out the code from the triggering event (`${{ github.event.workflow_run.head_sha }}`). If the triggering PR is from a malicious fork, and the workflow executes any code from that checkout (e.g., via `jules-action` or implicit dependencies), it creates a Remote Code Execution (RCE) vector.
+**Reference:** Memory explicitly states: "Self-healing workflows... must be restricted to `contents: read` permissions to prevent direct code commits, favoring issue creation".
+**Action:** Change `contents: write` to `contents: read`. Remove the logic that commits fixes directly.
+
+### CRITICAL: Supply Chain Security (Pinned Tags)
+**Files:** `.github/workflows/jules_review.yml`, `.github/workflows/self_healing.yml`
+**Issue:** The action `google-labs-code/jules-action@v1.0.0` is pinned to a mutable tag (`v1.0.0`).
+**Risk:** Tags can be moved by the action maintainer (or an attacker with access to their repo) to point to malicious code.
+**Reference:** Memory states: "External GitHub Actions... should be pinned to a specific commit SHA rather than a tag".
+**Action:** Pin the action to its immutable SHA.
+
+## 2. Reliability and Edge Cases
+
+### HIGH: Infinite Loop Risk
+**File:** `.github/workflows/self_healing.yml`
+**Issue:** The workflow triggers on CI failure, and attempts to commit a fix to the branch. This commit will trigger a new CI run. If the fix fails (CI fails again), the self-healing workflow runs again, creating an infinite loop.
+**Risk:** Consuming all Actions minutes and potential denial of service.
+**Reference:** Memory states: "must include safeguards to prevent recursive loops (e.g., verifying the triggering actor is not the bot)".
+**Action:** Add a condition to skip execution if the triggering actor is the bot.
+```yaml
+if: ${{ github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.actor.login != 'google-labs-jules[bot]' }}
+```
+
+## 3. Test Coverage Gaps
+
+### Findings
+*   **Python Code:** Good coverage (92%). The recent hooks (`stop-hook.py`, `prevent-push.py`) are covered by tests in `tests/agent/`.
+*   **Workflows:** The new workflows (`jules_review.yml`, `self_healing.yml`) are not tested. This is expected for workflows, but increases the reliance on manual review (and emphasizes the security issues above).
+
+## 4. Performance Risks
+
+### Low: Full History Fetch
+**File:** `.github/workflows/jules_review.yml`, `.github/workflows/self_healing.yml`
+**Issue:** `fetch-depth: 0` fetches the entire history.
+**Risk:** Slower checkout times for large repositories.
+**Mitigation:** Acceptable for now as `jules-action` likely needs history for context/diff analysis.
+
+## Summary
+The PR introduces significant security risks in the GitHub Actions configuration. **Do not merge** until the permissions are downgraded, actions are pinned to SHAs, and the infinite loop guard is implemented.


### PR DESCRIPTION
Added detailed PR review findings to `PR_REVIEW.md`, highlighting critical security regressions in self-healing workflow permissions and action pinning, as well as reliability risks regarding infinite loops.

---
*PR created automatically by Jules for task [4971653248945556989](https://jules.google.com/task/4971653248945556989) started by @itsimonfredlingjack*