### PR TITLE
docs: Add PR_REVIEW.md with security and reliability feedback

### DIFF
--- a/PR_REVIEW.md
+++ b/PR_REVIEW.md
@@ -1,0 +1,30 @@
+# PR Review Feedback
+
+## 1. Security Regressions
+
+### Critical: Unsafe `contents: write` Permission in Self-Healing Workflow
+**File:** `.github/workflows/self_healing.yml`
+**Issue:** The workflow grants `contents: write` permission.
+**Risk:** This allows the workflow to push commits directly to the repository. Combined with the `workflow_run` trigger which can run on code from forks (via `head_sha`), this presents a critical security risk (RCE/Privilege Escalation).
+**Policy Violation:** Project guidelines strictly state that self-healing workflows must be restricted to `contents: read` permissions.
+**Action:** Change `contents: write` to `contents: read`. Remove logic that commits code. Use `issues: write` to report findings instead.
+
+### High: Unpinned GitHub Actions
+**Files:** `.github/workflows/jules_review.yml`, `.github/workflows/self_healing.yml`
+**Issue:** Workflows use `google-labs-code/jules-action@v1.0.0`.
+**Risk:** Mutable tags (like `v1.0.0`) can be updated with malicious code. External actions must be pinned to a specific immutable commit SHA.
+**Action:** Pin the `google-labs-code/jules-action` to its specific commit SHA.
+
+## 2. Reliability and Edge Cases
+
+### High: Potential Recursive Loop
+**File:** `.github/workflows/self_healing.yml`
+**Issue:** The workflow does not check if the triggering actor is the bot itself.
+**Risk:** If the self-healing workflow were to commit a fix (which it attempts to do), that commit would trigger the CI workflow, which could fail and trigger self-healing again, creating an infinite loop.
+**Action:** Add a safeguard: `if: ${{ github.actor != 'google-labs-jules[bot]' }}` (or the relevant bot username).
+
+## 3. Test Coverage Gaps
+The workflows themselves are not tested (which is expected for GHA), but the logic they invoke (the Jules action) is external. Ensure that any scripts or local actions used are covered by tests.
+
+## 4. Performance Risks
+No significant performance risks detected, assuming the Jules Action has reasonable timeouts.


### PR DESCRIPTION
Added PR_REVIEW.md detailing critical security regressions in self_healing.yml (contents: write), unpinned actions, and reliability risks (recursive loops).

---
*PR created automatically by Jules for task [1047335748833296253](https://jules.google.com/task/1047335748833296253) started by @itsimonfredlingjack*