### PR TITLE
docs: Add PR review findings

### DIFF
--- a/PR_REVIEW.md
+++ b/PR_REVIEW.md
@@ -1,0 +1,39 @@
+# PR Review Findings
+
+## Security Regressions
+
+### Critical: RCE Risk in Self-Healing Workflow
+- **File:** `.github/workflows/self_healing.yml`
+- **Issue:** The workflow triggers on `workflow_run` (which runs in the context of the base branch) but checks out the code from the *triggering* workflow's head SHA (`ref: ${{ github.event.workflow_run.head_sha }}`). Crucially, it has `contents: write` permission.
+- **Risk:** If a malicious actor opens a PR from a fork with a modified workflow or code that the self-healing action executes, they can achieve Remote Code Execution (RCE) with write permissions to the repository. This allows them to push malicious code to the base branch.
+- **Recommendation:**
+  - **Remove `contents: write` permission.** Stick to `issues: write` as per security guidelines.
+  - **Do not checkout untrusted code** (from `head_sha`) in a privileged context.
+  - If code modification is absolutely necessary, it should be done in a sandboxed environment or via a PR that requires human approval, not automatically.
+
+### High: Unpinned GitHub Actions
+- **File:** `.github/workflows/self_healing.yml`, `.github/workflows/jules_review.yml`
+- **Issue:** Both workflows use `google-labs-code/jules-action@v1.0.0`.
+- **Risk:** Mutable tags (like `v1.0.0`) can be updated by the action maintainer. If the action is compromised, the tag can point to malicious code.
+- **Recommendation:** Pin the action to a specific immutable commit SHA (e.g., `uses: google-labs-code/jules-action@<COMMIT_SHA>`).
+
+## Reliability and Edge Cases
+
+### High: Potential Recursive Loop in Self-Healing
+- **File:** `.github/workflows/self_healing.yml`
+- **Issue:** The workflow runs on `workflow_run` completion of "CI". If the self-healing job commits a fix (which triggers "CI"), and that CI fails again, the self-healing workflow will trigger again, creating an infinite loop.
+- **Recommendation:** Add a condition to ignore runs triggered by the self-healing bot itself.
+  ```yaml
+  if: ${{ github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.actor.login != 'google-labs-jules[bot]' }}
+  ```
+
+## Performance Risks
+
+### Medium: Full History Fetch
+- **File:** `.github/workflows/self_healing.yml`, `.github/workflows/jules_review.yml`
+- **Issue:** Both workflows use `fetch-depth: 0` in the checkout step.
+- **Risk:** This downloads the entire history of the repository. As the repo grows, this will significantly slow down the workflow and increase bandwidth usage.
+- **Recommendation:** Use `fetch-depth: 1` or a limited depth unless the full history is explicitly required by the Jules action (e.g., for `git log` analysis). If `include_commit_log: true` requires history, consider fetching only `fetch-depth: 100` or similar.
+
+## Test Coverage
+- **Status:** These are workflow files, so standard unit tests do not apply. However, integration testing of these workflows in a safe environment is recommended before merging.


### PR DESCRIPTION
Add actionable feedback for security regressions, reliability risks, and edge cases in PR_REVIEW.md.

Findings include:
- Critical security risk in `self_healing.yml` due to `contents: write` permissions on `workflow_run` triggers.
- Security risk from unpinned `google-labs-code/jules-action` usage.
- Reliability risk of recursive loops in self-healing workflow.


---
*PR created automatically by Jules for task [3633421361484175971](https://jules.google.com/task/3633421361484175971) started by @itsimonfredlingjack*