### PR TITLE
docs: add security and reliability review feedback

### DIFF
--- a/PR_REVIEW.md
+++ b/PR_REVIEW.md
@@ -1,0 +1,31 @@
+# PR Review
+
+## 1. Security Regressions
+
+### Critical: Unsafe Permissions in `self_healing.yml`
+The `self_healing.yml` workflow currently requests `contents: write`.
+**Recommendation:** Change `contents: write` to `contents: read`. Self-healing workflows triggered by `workflow_run` must not have write access to the repository to prevent potential malicious code injection or accidental commits. Use `issues: write` to report findings instead.
+
+### Critical: Missing Recursion Safeguard
+The `self_healing.yml` workflow does not verify if the triggering actor is the bot itself (`google-labs-jules[bot]`).
+**Recommendation:** Add a condition to ensure the workflow does not run if the triggering actor is the Jules bot. This prevents infinite loops where the bot attempts to heal its own changes.
+
+### High: Action Pinning
+The workflows use `google-labs-code/jules-action@v1.0.0`.
+**Recommendation:** Pin the action to a specific immutable commit SHA (e.g., `uses: google-labs-code/jules-action@<SHA>`) instead of a tag. Tags can be moved, posing a security risk.
+
+### High: RCE Risk with Fork Checkout
+Checking out `${{ github.event.workflow_run.head_sha }}` with `contents: write` permissions is dangerous if the PR comes from a fork.
+**Recommendation:** Combined with restricting permissions to `contents: read`, ensure that the checkout step is safe.
+
+## 2. Reliability and Edge Cases
+
+### Conflicting Instructions
+The `self_healing.yml` prompt instructs the agent to "commit the fix", but the workflow should be read-only.
+**Recommendation:** Update the prompt to remove instructions about committing fixes. The agent should only analyze and propose fixes via issues.
+
+## 3. Performance Risks
+
+### `fetch-depth: 0`
+Both workflows use `fetch-depth: 0` during checkout.
+**Recommendation:** Avoid `fetch-depth: 0` unless the full history is strictly required for the analysis. For most reviews, a shallower fetch or just the PR commits might suffice, improving performance on large repositories.


### PR DESCRIPTION
Adds `PR_REVIEW.md` with actionable feedback regarding `self_healing.yml` permissions, action pinning, recursion safeguards, and performance optimizations.

---
*PR created automatically by Jules for task [9002155655998968171](https://jules.google.com/task/9002155655998968171) started by @itsimonfredlingjack*