### PR TITLE
fix: secure self-healing workflow and support fork checkout

### DIFF
--- a/.github/workflows/self_healing.yml
+++ b/.github/workflows/self_healing.yml
@@ -6,7 +6,7 @@ on:
     types: [completed]
 
 permissions:
-  contents: write
+  contents: read
   pull-requests: write
   issues: write
 
@@ -31,6 +31,7 @@ jobs:
         if: ${{ steps.secret_check.outputs.available == 'true' }}
         uses: actions/checkout@v4
         with:
+          repository: ${{ github.event.workflow_run.head_repository.full_name }}
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
 


### PR DESCRIPTION
Hardens the self-healing workflow by restricting permissions to `contents: read` to prevent RCE. Updates `actions/checkout` to correctly handle fork repositories in `workflow_run` events by specifying the repository name. This fixes the likely root cause of self-healing failures on fork PRs and addresses critical security vulnerabilities.

---
*PR created automatically by Jules for task [12771819777991855453](https://jules.google.com/task/12771819777991855453) started by @itsimonfredlingjack*