### PR TITLE
fix: harden self_healing workflow security

### DIFF
--- a/.github/workflows/self_healing.yml
+++ b/.github/workflows/self_healing.yml
@@ -6,7 +6,7 @@ on:
     types: [completed]
 
 permissions:
-  contents: write
+  contents: read
   pull-requests: write
   issues: write
 
@@ -42,7 +42,5 @@ jobs:
           prompt: |
             The CI workflow failed.
             Analyze likely root causes and propose a minimal fix.
-            If a deterministic safe fix is obvious, commit the fix to
-            branch ${{ github.event.workflow_run.head_branch }}.
-            Otherwise, open an issue with analysis and a remediation plan.
+            Open an issue with analysis and a remediation plan.
           include_commit_log: true


### PR DESCRIPTION
Hardened the self-healing workflow by reducing permissions and changing the remediation strategy to issue creation. This aligns with security best practices for `workflow_run` events.

---
*PR created automatically by Jules for task [17200178639396337923](https://jules.google.com/task/17200178639396337923) started by @itsimonfredlingjack*