### PR TITLE
feat: trigger self-healing from branch CI (push)

### DIFF
--- a/.github/workflows/ci_branch.yml
+++ b/.github/workflows/ci_branch.yml
@@ -1,0 +1,70 @@
+name: CI Branch
+
+on:
+  push:
+    branches-ignore: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest pytest-cov ruff flask
+
+      - name: Run linting
+        run: |
+          ruff check . --output-format=github
+
+      - name: Run tests with coverage
+        run: |
+          pytest -xvs --cov=src --cov=app.py --cov-report=xml --cov-report=term-missing --cov-fail-under=80
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install ruff
+        run: pip install ruff
+
+      - name: Run ruff check
+        run: ruff check . --output-format=github
+
+      - name: Run ruff format check
+        run: ruff format --check .
+
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install safety
+        run: pip install safety
+
+      - name: Check for security vulnerabilities
+        run: |
+          pip install flask pytest
+          safety check --full-report || true

--- a/.github/workflows/self_healing.yml
+++ b/.github/workflows/self_healing.yml
@@ -2,7 +2,7 @@ name: Self Healing
 
 on:
   workflow_run:
-    workflows: ["CI"]
+    workflows: ["CI Branch"]
     types: [completed]
 
 permissions:
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   heal-failure:
-    if: ${{ github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.event == 'pull_request' }}
+    if: ${{ github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.event == 'push' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
 

--- a/docs/jules-playbook.md
+++ b/docs/jules-playbook.md
@@ -13,6 +13,7 @@ runs, and `jules_health_check.yml` validates integration health on schedule.
 - **PR review:** `.github/workflows/jules_review.yml`
 - **Self-healing:** `.github/workflows/self_healing.yml`
 - **Health check:** `.github/workflows/jules_health_check.yml`
+- **Branch CI (feeds self-healing):** `.github/workflows/ci_branch.yml`
 
 ## Payload and guardrails
 


### PR DESCRIPTION
Self-healing is triggered via workflow_run. In practice, workflow_run is not emitted for pull_request-triggered CI runs in a way we can rely on. This adds a branch-push CI and triggers self-healing from that.

Changes:
- Add .github/workflows/ci_branch.yml (CI Branch) that runs on push to non-main branches.
- Update .github/workflows/self_healing.yml to listen to CI Branch failures (event=push).
- Update docs/jules-playbook.md to document CI Branch.

Result:
- PR review stays the same.
- Self-healing works for PR branches because every push to the PR branch runs CI Branch.
