### PR TITLE
docs: Add PR review findings to agent/PR_REVIEW.md

### DIFF
--- a/agent/PR_REVIEW.md
+++ b/agent/PR_REVIEW.md
@@ -1,0 +1,38 @@
+# PR Review Findings
+
+## 1. Security Regressions
+
+### Critical: Remote Code Execution (RCE) in Self-Healing Workflow
+**Context:** The `self_healing.yml` workflow triggers on `workflow_run` (which runs in the context of the base repo) but checks out the `head_sha` of the PR and executes Python scripts (`scripts/classify_failure.py`, etc.) from that untrusted revision. Combined with the `contents: write` permission, a malicious PR can modify these scripts to exfiltrate secrets or push malicious code to the repository.
+**Action Required:**
+- Change `contents: write` to `contents: read` if possible, or strictly restrict scope.
+- Checkout scripts from the base repository (trusted context) or run them in a restricted sandbox.
+
+### High: Hardcoded Admin Credentials
+**Context:** The `AdminAuthService` in `src/sejfa/core/admin_auth.py` uses hardcoded credentials (`admin` / `admin123`). This is a severe security risk if deployed.
+**Action Required:**
+- Replace hardcoded credentials with environment variable lookups or a secure secret management system.
+
+### High: Broken Workflow Dependency
+**Context:** The `jules_health_check.yml` workflow executes `bash scripts/preflight.sh`, but this file does not exist in the repository. This will cause the health check to fail consistently.
+**Action Required:**
+- Restore the missing `scripts/preflight.sh` script or remove the step.
+
+### Medium: Supply Chain Security (Action Pinning)
+**Context:** `self_healing.yml`, `jules_review.yml`, and `jules_health_check.yml` use `google-labs-code/jules-action@v1.0.0`. Pinning to a tag is vulnerable to tag hijacking.
+**Action Required:**
+- Pin the action to a specific immutable commit SHA.
+
+## 2. Reliability and Edge Cases
+
+### Medium: Missing Recursion Safeguard
+**Context:** The `self_healing.yml` workflow lacks a check to prevent recursive loops. If a commit made by the bot triggers a CI failure, this workflow will trigger again indefinitely.
+**Action Required:**
+- Add a condition to verify the triggering actor is not `google-labs-jules[bot]`.
+
+## 3. Policy Violations
+
+### High: Review Artifact Placement
+**Context:** The PR attempted to add `PR_REVIEW.md` to the root directory.
+**Action Required:**
+- Review artifacts must be placed in `agent/` directory to comply with clean root policy. This file has been created at `agent/PR_REVIEW.md` instead.


### PR DESCRIPTION
Consolidated PR review findings and placed them in the correct directory (agent/) to comply with clean root policy. Findings include RCE risk, hardcoded credentials, and missing dependencies.

---
*PR created automatically by Jules for task [1054809794177686496](https://jules.google.com/task/1054809794177686496) started by @itsimonfredlingjack*