### PR TITLE
chore(loop): align Jira transitions to In Progress -> In Review -> Done

### DIFF
--- a/.claude/skills/start-task/SKILL.md
+++ b/.claude/skills/start-task/SKILL.md
@@ -328,6 +328,11 @@ except Exception as e:
 
 Note: Continue even if transition fails - it's not critical.
 
+Required status order for this project:
+- `transition_issue('{JIRA_ID}', 'In Progress')` when work starts
+- `transition_issue('{JIRA_ID}', 'In Review')` when implementation is complete and awaiting review
+- `transition_issue('{JIRA_ID}', 'Done')` when review is approved
+
 ### Step 8: Add Jira Comment
 
 Log that the agent has started work using the direct API via Bash:


### PR DESCRIPTION
## Summary
- update loop skill docs to use the Jira status order now configured in project GE:
  - `In Progress` when work starts
  - `In Review` when implementation is ready for review
  - `Done` when review is approved
- add explicit `Done` transition step in finish-task when PR state is merged

## Why
The Jira workflow now includes a real `In Review` transition and the loop docs needed to match it, so tickets don't get stuck in `In Progress`.

## Validation
- `pytest -q`
- `ruff check .`
- `ruff format --check .`
