### PR TITLE
GE-98: Implement Botanical Garden / Organic Zen theme

### DIFF
--- a/CURRENT_TASK.md
+++ b/CURRENT_TASK.md
@@ -1,66 +1,52 @@
-# CURRENT_TASK: GE-93 — The "Napkin Sketch" / Wireframe
+# CURRENT TASK: GE-98
 
 ## Ticket Info
-
-- **Jira ID:** GE-93
-- **Summary:** The "Napkin Sketch" / Wireframe
+- **Jira ID:** GE-98
+- **Branch:** feature/GE-98-green-organic
 - **Type:** Task
 - **Priority:** Medium
-- **Branch:** `feature/GE-93-the-napkin-sketch-wireframe`
 - **Status:** In Progress
+
+## Summary
+Green & Organic - "Botanical Garden / Organic Zen" Theme
 
 ## Description
 
 <ticket>
-Ett "Low-fidelity" utseende som är väldigt charmigt. Det ser ut som en idé skissad på en servett på ett kafé.
+This is the "Wow factor" theme. It shows the AI understands texture and mood. It should feel like a digital greenhouse.
 
-**Maximal Change Title:** Reskin to "Hand-Drawn Sketch / Blueprint" theme
+**Maximal Change Title:** Reskin to "Botanical Garden / Organic Zen" theme
 
-**Description:** Make the entire app look like a rough sketch drawn with a blue ballpoint pen on a paper napkin.
+**Description:** Transform the interface into a lush, organic environment. It should feel less like software and more like a living terrarium.
 
-- **Background:** A texture of a white paper napkin or wrinkled notebook paper.
-- **Style/Feel:** Lo-Fi / Sketchy. Wobbly lines (scribble effect). Incomplete borders. It should look unfinished and brainstorming-friendly.
-- **Colors:** Ink Blue (#00008B) for all lines and text. No other colors, just shading with cross-hatching (streck) for depth.
-- **Fonts:** A messy Handwritten font (like *Architects Daughter* or *Permanent Marker*).
-- **Cards &amp; Panels:** Look like rough rectangles drawn by hand. Fill backgrounds with a "scribble" fill instead of solid colors.
-- **Layout:** Arrows should look hand-drawn with loops and uneven heads.
+- **Background:** A soft, pale sage green (#F1F8E9). Overlay a subtle "dappled sunlight" shadow effect (as if light is filtering through leaves).
+- **Style/Feel:** Biophilic Design. Soft, natural, and tactile. Avoid sharp digital edges.
+- **Colors:** A palette of deep forest greens (#2E7D32) for text, earthy terracotta (#D84315) for alerts, and soft fern green for success states.
+- **Fonts:** Serif for headers (e.g., Merriweather or Playfair Display) to give an elegant, editorial look. Clean, rounded Sans-Serif for data.
+- **Cards & Panels:** Cards should look like high-quality, thick paper or cardstock. Use soft, diffused drop shadows to lift them off the background. Rounded corners (20px radius).
+- **Layout:** Connecting lines should be organic curves (bezier curves), resembling vines or stems. Use small leaf icons 🍃 instead of standard dots for nodes.
 </ticket>
 
 ## Acceptance Criteria
+- [ ] Background: soft pale sage green (#F1F8E9) with dappled sunlight shadow overlay effect
+- [ ] Colors: deep forest green (#2E7D32) for text, terracotta (#D84315) for alerts, fern green for success
+- [ ] Fonts: Serif (Merriweather/Playfair Display) for headers, rounded sans-serif for data
+- [ ] Cards: paper/cardstock feel, soft diffused shadows, 20px border-radius
+- [ ] Layout: bezier curve organic connecting lines, leaf 🍃 icons instead of dots for nodes
+- [ ] Biophilic aesthetic: feels like a living terrarium/digital greenhouse
+- [ ] All tests pass
+- [ ] Linting passes
 
-- [x] App has a paper napkin / wrinkled notebook paper background texture (CSS ruled lines + red margin line)
-- [x] All text uses a handwritten font (Architects Daughter from Google Fonts)
-- [x] Primary color is Ink Blue (#00008B) — no other colors
-- [x] Borders/lines look wobbly/sketchy (border-radius: 255px trick, SVG feTurbulence filter defined)
-- [x] Cards/panels have rough hand-drawn rectangle appearance with cross-hatch fill (repeating-linear-gradient)
-- [x] The theme applies to all Flask-rendered templates (base.html, newsflash/index.html, subscribe.html, thank_you.html, expense_tracker/base.html, expense_tracker/index.html, expense_tracker/summary.html)
-- [x] All existing tests pass (383 passed, 12 skipped)
-- [x] Linting passes (ruff)
+## Progress Log
+
+| Iteration | Date | Action | Result |
+|-----------|------|--------|--------|
+| 1 | 2026-02-17 | Branch created, ticket fetched | ✅ |
 
 ## Files to Modify
-
-Per CLAUDE.md production file map:
-- `src/sejfa/newsflash/presentation/templates/base.html` (main base template)
-- `src/sejfa/newsflash/presentation/templates/newsflash/index.html`
-- `src/sejfa/newsflash/presentation/templates/newsflash/subscribe.html`
-- `src/sejfa/newsflash/presentation/templates/newsflash/thank_you.html`
-- `src/expense_tracker/templates/expense_tracker/base.html`
-- `src/expense_tracker/templates/expense_tracker/index.html`
-- `src/expense_tracker/templates/expense_tracker/summary.html`
-
-## Progress
-
-| # | Iteration | Action | Result |
-|---|-----------|--------|--------|
-| 1 | 2026-02-17 | Task initialized, branch created | ✅ |
-| 2 | 2026-02-17 | Implemented Napkin Sketch theme in both base templates | ✅ |
-| 3 | 2026-02-17 | All 383 tests pass, ruff lint clean | ✅ |
+- `src/sejfa/newsflash/presentation/templates/base.html` (main app base)
+- `src/expense_tracker/templates/expense_tracker/base.html` (expense tracker base)
 
 ## Notes
-
-- Theme: Hand-Drawn Sketch / Blueprint ("Napkin Sketch")
-- Same pattern as GE-86 (GPU overheat) and GE-91 (Claymorphism) — visual theme reskin
-- Reference: GE-91 branch `feature/GE-91-the-playful-tactile-3d` for pattern
-- Google Fonts to use: `Architects Daughter` (primary) or `Permanent Marker`
-- Cross-hatching can be done with CSS `repeating-linear-gradient` patterns
-- Wobbly borders: use `border-radius` with irregular values or SVG `feTurbulence` filter
+- This is a theme/UI ticket - modifying Flask templates
+- Similar pattern to GE-86 (cyber-glitch), GE-91 (claymorphism), GE-93 (napkin sketch)

--- a/src/expense_tracker/templates/expense_tracker/base.html
+++ b/src/expense_tracker/templates/expense_tracker/base.html
@@ -6,27 +6,43 @@
     <title>{% block title %}ExpenseTracker{% endblock %}</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Architects+Daughter&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,700;1,400&family=Nunito:wght@300;400;600&display=swap" rel="stylesheet">
     <style>
         :root {
-            /* Napkin Sketch / Hand-Drawn Blueprint Theme */
-            --ink: #00008B;
-            --ink-75: rgba(0, 0, 139, 0.75);
-            --ink-40: rgba(0, 0, 139, 0.40);
-            --ink-20: rgba(0, 0, 139, 0.20);
-            --ink-10: rgba(0, 0, 139, 0.10);
-            --ink-06: rgba(0, 0, 139, 0.06);
-            --ink-03: rgba(0, 0, 139, 0.03);
-            --paper: #FFF9F0;
-            --paper-card: #FFFEF8;
-            --margin-red: rgba(210, 60, 60, 0.35);
+            /* Botanical Garden / Organic Zen Theme */
+            --forest: #2E7D32;
+            --forest-75: rgba(46, 125, 50, 0.75);
+            --forest-40: rgba(46, 125, 50, 0.40);
+            --forest-20: rgba(46, 125, 50, 0.20);
+            --forest-10: rgba(46, 125, 50, 0.10);
+            --forest-06: rgba(46, 125, 50, 0.06);
+            --forest-03: rgba(46, 125, 50, 0.03);
+            --sage-bg: #F1F8E9;
+            --parchment: #FAFFF5;
+            --parchment-card: #F7FBF0;
+            --terracotta: #D84315;
+            --terracotta-light: rgba(216, 67, 21, 0.12);
+            --fern: #558B2F;
+            --fern-light: rgba(85, 139, 47, 0.12);
         }
 
-        .sketch-filter-defs {
-            position: absolute;
-            width: 0;
-            height: 0;
-            overflow: hidden;
+        /* ─── ANIMATIONS ─── */
+        @keyframes dapple-drift {
+            0%   { transform: translate(0%,  0%)   scale(1);    opacity: 0.55; }
+            33%  { transform: translate(3%,  2%)   scale(1.05); opacity: 0.40; }
+            66%  { transform: translate(-2%, 4%)   scale(0.97); opacity: 0.50; }
+            100% { transform: translate(0%,  0%)   scale(1);    opacity: 0.55; }
+        }
+
+        @keyframes leaf-sway {
+            0%,  100% { transform: rotate(0deg)    translateY(0);   }
+            30%        { transform: rotate(1.2deg)  translateY(-2px); }
+            70%        { transform: rotate(-0.8deg) translateY(1px);  }
+        }
+
+        @keyframes sprout {
+            0%   { transform: scale(0.95) translateY(6px); opacity: 0; }
+            100% { transform: scale(1)    translateY(0);   opacity: 1; }
         }
 
         * {
@@ -35,39 +51,11 @@
             box-sizing: border-box;
         }
 
-        @keyframes sketch-jitter {
-            0%, 100% { transform: rotate(0deg) translateY(0); }
-            25% { transform: rotate(0.4deg) translateY(-1px); }
-            75% { transform: rotate(-0.3deg) translateY(1px); }
-        }
-
-        @keyframes sketch-pop {
-            0% { transform: scale(0.97) rotate(-1deg); opacity: 0.7; }
-            60% { transform: scale(1.02) rotate(0.5deg); }
-            100% { transform: scale(1) rotate(0deg); opacity: 1; }
-        }
-
         body {
             min-height: 100vh;
-            font-family: 'Architects Daughter', 'Comic Sans MS', cursive;
-            background-color: var(--paper);
-            background-image:
-                /* Red margin line */
-                linear-gradient(90deg,
-                    transparent 62px,
-                    var(--margin-red) 62px,
-                    var(--margin-red) 64px,
-                    transparent 64px
-                ),
-                /* Horizontal ruled lines */
-                repeating-linear-gradient(
-                    transparent,
-                    transparent 27px,
-                    var(--ink-10) 27px,
-                    var(--ink-10) 28px
-                );
-            background-attachment: local;
-            color: var(--ink);
+            font-family: 'Nunito', 'Segoe UI', sans-serif;
+            background-color: var(--sage-bg);
+            color: var(--forest);
             position: relative;
             overflow-x: hidden;
             padding: 0;
@@ -75,30 +63,50 @@
             line-height: 1.7;
         }
 
+        /* Dappled sunlight layer */
+        body::before {
+            content: '';
+            position: fixed;
+            inset: 0;
+            pointer-events: none;
+            z-index: 0;
+            background-image:
+                radial-gradient(ellipse 180px 110px at 12%  8%,  rgba(255,255,200,0.30) 0%, transparent 70%),
+                radial-gradient(ellipse 220px 150px at 72%  4%,  rgba(255,255,180,0.24) 0%, transparent 70%),
+                radial-gradient(ellipse 130px 200px at 92% 38%,  rgba(255,255,210,0.22) 0%, transparent 70%),
+                radial-gradient(ellipse 200px 110px at 38% 62%,  rgba(255,255,200,0.18) 0%, transparent 70%),
+                radial-gradient(ellipse 160px 180px at  4% 78%,  rgba(255,255,190,0.20) 0%, transparent 70%),
+                radial-gradient(ellipse 110px 130px at 58% 88%,  rgba(255,255,200,0.16) 0%, transparent 70%);
+            animation: dapple-drift 22s ease-in-out infinite;
+        }
+
+        /* Headings — Playfair Display serif */
         h1, h2, h3, h4, h5, h6 {
-            font-family: 'Architects Daughter', cursive;
-            font-weight: normal;
-            color: var(--ink);
+            font-family: 'Playfair Display', Georgia, serif;
+            font-weight: 700;
+            color: var(--forest);
             margin-bottom: 20px;
             position: relative;
             z-index: 10;
             line-height: 1.3;
-            letter-spacing: 0.5px;
+            letter-spacing: 0.3px;
         }
 
         h1::after, h2::after {
             content: '';
             display: block;
             height: 2px;
-            background: var(--ink-40);
-            border-radius: 2px 4px 1px 3px;
+            background: linear-gradient(90deg, var(--fern), rgba(85,139,47,0.4) 60%, transparent);
+            border-radius: 2px;
             margin-top: 6px;
-            transform: rotate(-0.3deg);
         }
 
         h1 { font-size: 30px; }
         h2 { font-size: 24px; }
         h3 { font-size: 19px; }
+
+        /* List items use leaf nodes */
+        li::marker { content: '🍃  '; }
 
         /* ─── NAV ─── */
         nav {
@@ -107,59 +115,45 @@
             display: flex;
             gap: 14px;
             align-items: center;
-            background: var(--paper);
-            border-bottom: 3px solid var(--ink);
-            box-shadow: 0 3px 0 var(--ink-20), 0 5px 0 var(--ink-10);
+            background: rgba(241, 248, 233, 0.94);
+            border-bottom: 1.5px solid var(--forest-20);
+            box-shadow: 0 4px 20px var(--forest-10), 0 2px 8px var(--forest-06);
+            backdrop-filter: blur(6px);
             padding: 16px 30px;
             max-width: 100%;
             margin: 0 0 30px 0;
         }
 
         nav::before {
-            content: '📋 ';
+            content: '🌿 ';
             font-size: 18px;
             margin-right: 4px;
         }
 
         nav a {
-            font-family: 'Architects Daughter', cursive;
-            font-weight: normal;
-            color: var(--ink);
+            font-family: 'Nunito', sans-serif;
+            font-weight: 600;
+            color: var(--forest);
             text-decoration: none;
-            padding: 8px 20px;
-            border: 2px solid var(--ink);
-            border-radius: 255px 8px 225px 8px / 8px 225px 8px 255px;
+            padding: 8px 22px;
+            border: 1.5px solid var(--forest-40);
+            border-radius: 20px;
             font-size: 15px;
             letter-spacing: 0.3px;
-            transition: all 0.15s ease;
+            transition: all 0.2s ease;
             display: inline-block;
-            background: transparent;
-            position: relative;
-        }
-
-        nav a::after {
-            content: '';
-            position: absolute;
-            inset: 3px;
-            border: 1px solid var(--ink-20);
-            border-radius: 255px 8px 225px 8px / 8px 225px 8px 255px;
-            pointer-events: none;
+            background: var(--parchment);
+            box-shadow: 0 2px 8px var(--forest-10);
         }
 
         nav a:hover {
-            background-image: repeating-linear-gradient(
-                -45deg,
-                transparent,
-                transparent 4px,
-                var(--ink-06) 4px,
-                var(--ink-06) 5px
-            );
-            transform: translateY(-1px) rotate(0.4deg);
+            background: var(--fern-light);
+            border-color: var(--fern);
+            box-shadow: 0 4px 16px var(--forest-20);
+            transform: translateY(-1px);
         }
 
-        nav a:active {
-            transform: translateY(1px) rotate(-0.3deg);
-        }
+        nav a:active { transform: translateY(1px); }
 
         /* ─── FLASH MESSAGES ─── */
         .flash-messages {
@@ -172,38 +166,28 @@
         .flash {
             padding: 16px 22px;
             margin-bottom: 16px;
-            border: 2px solid var(--ink);
-            border-radius: 4px 8px 4px 6px / 6px 4px 8px 4px;
-            font-family: 'Architects Daughter', cursive;
+            border-radius: 16px;
+            font-family: 'Nunito', sans-serif;
             font-size: 15px;
-            letter-spacing: 0.3px;
+            letter-spacing: 0.2px;
             position: relative;
-            animation: sketch-pop 0.3s ease-out;
-            background-color: var(--paper-card);
-            background-image: repeating-linear-gradient(
-                -45deg,
-                transparent 0px, transparent 6px,
-                var(--ink-06) 6px, var(--ink-06) 7px
-            );
+            animation: sprout 0.3s ease-out;
         }
 
         .flash.error {
-            border-style: dashed;
+            background: var(--terracotta-light);
+            border: 1px solid var(--terracotta);
+            color: var(--terracotta);
         }
 
         .flash.success {
-            border-style: solid;
+            background: var(--fern-light);
+            border: 1px solid var(--fern);
+            color: var(--fern);
         }
 
-        .flash.error::before {
-            content: '⚠ ';
-            font-weight: bold;
-        }
-
-        .flash.success::before {
-            content: '✓ ';
-            font-weight: bold;
-        }
+        .flash.error::before   { content: '🌵 '; }
+        .flash.success::before { content: '🌱 '; }
 
         /* ─── EXPENSE LIST ─── */
         .expense-list {
@@ -216,34 +200,35 @@
         }
 
         .expense-item {
-            background-color: var(--paper-card);
-            background-image: repeating-linear-gradient(
-                -45deg,
-                transparent 0px, transparent 9px,
-                var(--ink-03) 9px, var(--ink-03) 10px
-            );
-            border: 2px solid var(--ink);
-            border-radius: 4px 8px 4px 6px / 6px 4px 8px 4px;
+            background: var(--parchment-card);
+            border: 1px solid var(--forest-20);
+            border-radius: 16px;
             padding: 16px 22px;
-            margin-bottom: 14px;
+            margin-bottom: 12px;
             display: flex;
             justify-content: space-between;
             align-items: center;
             position: relative;
-            transition: transform 0.15s ease;
+            /* Soft, diffused cardstock shadow */
+            box-shadow:
+                0 2px 4px   var(--forest-20),
+                0 6px 16px  var(--forest-10),
+                0 10px 30px var(--forest-06);
+            transition: all 0.2s ease;
         }
-
-        .expense-item:nth-child(odd) { transform: rotate(-0.2deg); }
-        .expense-item:nth-child(even) { transform: rotate(0.2deg); }
 
         .expense-item:hover {
-            transform: translateY(-2px) rotate(0deg);
+            transform: translateY(-2px);
+            box-shadow:
+                0 4px 10px  var(--forest-20),
+                0 10px 28px var(--forest-20),
+                0 20px 48px var(--forest-10);
         }
 
+        /* Leaf node marker — replacing standard dot */
         .expense-item::before {
-            content: '─ ';
-            color: var(--ink-40);
-            font-size: 12px;
+            content: '🍃';
+            font-size: 13px;
             position: absolute;
             left: 8px;
             top: 50%;
@@ -251,225 +236,168 @@
         }
 
         .expense-title {
-            font-family: 'Architects Daughter', cursive;
-            font-weight: normal;
-            color: var(--ink);
+            font-family: 'Playfair Display', Georgia, serif;
+            font-weight: 400;
+            color: var(--forest);
             font-size: 16px;
-            letter-spacing: 0.3px;
+            letter-spacing: 0.2px;
+            padding-left: 6px;
         }
 
         .expense-category {
-            font-family: 'Architects Daughter', cursive;
-            color: var(--ink-75);
+            font-family: 'Nunito', sans-serif;
+            color: var(--forest-75);
             font-size: 14px;
             font-style: italic;
             margin-left: 6px;
         }
 
         .expense-amount {
-            font-family: 'Architects Daughter', cursive;
+            font-family: 'Nunito', sans-serif;
             font-size: 17px;
-            font-weight: normal;
-            color: var(--ink);
-            border: 2px solid var(--ink);
-            padding: 4px 14px;
-            border-radius: 255px 6px 225px 6px / 6px 225px 6px 255px;
-            background: transparent;
-            background-image: repeating-linear-gradient(
-                -45deg,
-                transparent 0px, transparent 5px,
-                var(--ink-06) 5px, var(--ink-06) 6px
-            );
+            font-weight: 600;
+            color: var(--forest);
+            border: 1.5px solid var(--forest-40);
+            padding: 4px 16px;
+            border-radius: 20px;
+            background: var(--parchment);
+            box-shadow: 0 2px 6px var(--forest-10);
         }
 
         /* ─── FORM ─── */
         form {
-            background-color: var(--paper-card);
-            background-image: repeating-linear-gradient(
-                -45deg,
-                transparent 0px, transparent 9px,
-                var(--ink-03) 9px, var(--ink-03) 10px
-            );
-            border: 2px solid var(--ink);
-            border-radius: 255px 12px 225px 12px / 12px 225px 12px 255px;
+            background: var(--parchment-card);
+            border: 1px solid var(--forest-20);
+            border-radius: 24px;
             padding: 32px 30px;
             margin-bottom: 25px;
             position: relative;
             z-index: 10;
             max-width: 1000px;
             margin: 0 auto 30px;
+            box-shadow:
+                0 4px 8px   var(--forest-20),
+                0 10px 30px var(--forest-10),
+                0 20px 56px var(--forest-06);
         }
 
-        form::after {
-            content: '';
-            position: absolute;
-            inset: 6px;
-            border: 1px solid var(--ink-20);
-            border-radius: 255px 12px 225px 12px / 12px 225px 12px 255px;
-            pointer-events: none;
-        }
-
-        .form-group {
-            margin-bottom: 20px;
-        }
+        .form-group { margin-bottom: 20px; }
 
         label {
-            font-family: 'Architects Daughter', cursive;
+            font-family: 'Nunito', sans-serif;
             display: block;
             margin-bottom: 8px;
-            font-weight: normal;
-            color: var(--ink);
+            font-weight: 600;
+            color: var(--forest);
             font-size: 14px;
-            letter-spacing: 0.5px;
+            letter-spacing: 0.3px;
         }
 
-        label::before {
-            content: '> ';
-            color: var(--ink-40);
-        }
+        label::before { content: '🍃 '; }
 
         input, select {
             width: 100%;
             padding: 10px 14px;
-            background: var(--paper);
-            border: 2px solid var(--ink-75);
-            border-radius: 4px 6px 4px 5px / 5px 4px 6px 4px;
-            color: var(--ink);
-            font-family: 'Architects Daughter', cursive;
+            background: var(--parchment);
+            border: 1.5px solid var(--forest-40);
+            border-radius: 12px;
+            color: var(--forest);
+            font-family: 'Nunito', sans-serif;
             font-size: 15px;
-            transition: border-color 0.15s ease;
+            transition: all 0.2s ease;
         }
 
         input:focus, select:focus {
             outline: none;
-            border-color: var(--ink);
-            border-width: 2px;
-            box-shadow: 3px 3px 0 var(--ink-20);
+            border-color: var(--fern);
+            box-shadow: 0 0 0 3px var(--fern-light);
         }
 
         input::placeholder {
-            color: var(--ink-40);
+            color: var(--forest-40);
             font-style: italic;
         }
 
         button {
-            font-family: 'Architects Daughter', cursive;
-            font-weight: normal;
-            background: transparent;
-            background-image: repeating-linear-gradient(
-                -45deg,
-                transparent 0px, transparent 5px,
-                var(--ink-06) 5px, var(--ink-06) 6px
-            );
-            color: var(--ink);
-            border: 2px solid var(--ink);
+            font-family: 'Nunito', sans-serif;
+            font-weight: 600;
+            background: var(--forest);
+            color: #FAFFF5;
+            border: none;
             padding: 10px 32px;
-            border-radius: 255px 8px 225px 8px / 8px 225px 8px 255px;
+            border-radius: 20px;
             cursor: pointer;
             font-size: 15px;
-            letter-spacing: 0.5px;
-            transition: all 0.15s ease;
-            position: relative;
-        }
-
-        button::after {
-            content: '';
-            position: absolute;
-            inset: 4px;
-            border: 1px solid var(--ink-20);
-            border-radius: 255px 8px 225px 8px / 8px 225px 8px 255px;
-            pointer-events: none;
+            letter-spacing: 0.3px;
+            transition: all 0.2s ease;
+            box-shadow: 0 3px 12px var(--forest-40);
         }
 
         button:hover {
-            background-image: repeating-linear-gradient(
-                -45deg,
-                transparent 0px, transparent 4px,
-                var(--ink-10) 4px, var(--ink-10) 5px
-            ),
-            repeating-linear-gradient(
-                45deg,
-                transparent 0px, transparent 4px,
-                var(--ink-10) 4px, var(--ink-10) 5px
-            );
-            transform: translateY(-1px) rotate(0.5deg);
+            background: var(--fern);
+            box-shadow: 0 6px 22px var(--forest-40);
+            transform: translateY(-2px);
         }
 
-        button:active, button:focus {
-            transform: translateY(1px) rotate(-0.3deg);
-            outline: 2px dashed var(--ink);
+        button:active {
+            transform: translateY(1px);
+            box-shadow: 0 2px 6px var(--forest-20);
+        }
+
+        button:focus {
+            outline: 2px solid var(--fern);
             outline-offset: 4px;
         }
 
         /* ─── TOTAL DISPLAY ─── */
         .total {
-            font-family: 'Architects Daughter', cursive;
+            font-family: 'Playfair Display', Georgia, serif;
             font-size: 28px;
-            font-weight: normal;
-            color: var(--ink);
+            font-weight: 700;
+            color: var(--forest);
             margin: 40px 0;
             text-align: center;
             position: relative;
             z-index: 10;
-            background-color: var(--paper-card);
-            background-image:
-                repeating-linear-gradient(
-                    -45deg,
-                    transparent 0px, transparent 9px,
-                    var(--ink-03) 9px, var(--ink-03) 10px
-                ),
-                repeating-linear-gradient(
-                    45deg,
-                    transparent 0px, transparent 9px,
-                    var(--ink-03) 9px, var(--ink-03) 10px
-                );
-            border: 3px solid var(--ink);
-            border-radius: 255px 12px 225px 12px / 12px 225px 12px 255px;
+            background: var(--parchment-card);
+            border: 1px solid var(--forest-20);
+            border-radius: 24px;
             padding: 30px;
             max-width: 600px;
             margin: 40px auto;
-            letter-spacing: 0.5px;
-            animation: sketch-jitter 7s ease-in-out infinite;
+            letter-spacing: 0.3px;
+            box-shadow:
+                0 4px 8px   var(--forest-20),
+                0 10px 30px var(--forest-10),
+                0 20px 56px var(--forest-06);
+            animation: leaf-sway 8s ease-in-out infinite;
         }
 
         .total::before {
-            content: '∑ ';
-            font-size: 20px;
-            color: var(--ink-40);
-        }
-
-        .total::after {
-            content: '';
-            position: absolute;
-            inset: 6px;
-            border: 1px solid var(--ink-20);
-            border-radius: 255px 12px 225px 12px / 12px 225px 12px 255px;
-            pointer-events: none;
+            content: '🌿 ';
+            font-size: 22px;
         }
 
         /* ─── EMPTY MESSAGE ─── */
         .empty-message {
-            font-family: 'Architects Daughter', cursive;
-            color: var(--ink-75);
+            font-family: 'Playfair Display', Georgia, serif;
+            font-style: italic;
+            color: var(--forest-75);
             text-align: center;
             font-size: 16px;
-            font-style: italic;
             position: relative;
             z-index: 10;
-            background: var(--paper-card);
-            border: 2px dashed var(--ink-40);
-            border-radius: 4px 8px 4px 6px;
+            background: var(--parchment-card);
+            border: 1px dashed var(--forest-40);
+            border-radius: 16px;
             padding: 28px;
             margin: 25px auto;
             max-width: 500px;
+            box-shadow: 0 4px 16px var(--forest-06);
         }
 
-        .empty-message::before {
-            content: '( ';
-        }
-        .empty-message::after {
-            content: ' )';
-        }
+        .empty-message::before { content: '🍃 '; }
+        .empty-message::after  { content: ' 🌱'; }
 
         /* ─── CONTAINER ─── */
         .container {
@@ -482,40 +410,44 @@
 
         /* ─── LINKS ─── */
         a {
-            font-family: 'Architects Daughter', cursive;
-            font-weight: normal;
-            color: var(--ink);
+            font-family: 'Nunito', sans-serif;
+            font-weight: 600;
+            color: var(--fern);
             text-decoration: underline;
             text-decoration-style: dotted;
+            text-decoration-color: var(--fern);
             text-underline-offset: 3px;
             padding: 0;
             background: transparent;
             display: inline;
-            letter-spacing: 0.3px;
+            letter-spacing: 0.2px;
             font-size: inherit;
             transition: text-decoration-style 0.15s ease;
         }
 
         a:hover {
             text-decoration-style: solid;
+            color: var(--forest);
         }
 
         /* Nav links styled differently */
         nav a {
             text-decoration: none;
-            padding: 8px 20px;
+            padding: 8px 22px;
             display: inline-block;
+            color: var(--forest);
         }
     </style>
 </head>
 <body>
-    <svg class="sketch-filter-defs" aria-hidden="true">
-        <defs>
-            <filter id="sketchy-border" x="-5%" y="-5%" width="110%" height="110%">
-                <feTurbulence type="turbulence" baseFrequency="0.04" numOctaves="4" seed="5" result="noise"/>
-                <feDisplacementMap in="SourceGraphic" in2="noise" scale="2" xChannelSelector="R" yChannelSelector="G"/>
-            </filter>
-        </defs>
+    <!-- Decorative organic SVG vines — bezier curves as stems -->
+    <svg aria-hidden="true" style="position:fixed;bottom:0;left:0;width:300px;height:280px;pointer-events:none;z-index:0;opacity:0.08;" viewBox="0 0 300 280" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path d="M15 280 C 35 210, 70 195, 50 140 C 30 85, 90 65, 80 10" stroke="#2E7D32" stroke-width="2.5" stroke-linecap="round"/>
+        <path d="M50 140 C 90 130, 120 105, 150 85" stroke="#558B2F" stroke-width="1.8" stroke-linecap="round"/>
+        <path d="M80 200 C 115 190, 145 172, 165 145" stroke="#558B2F" stroke-width="1.5" stroke-linecap="round"/>
+        <circle cx="150" cy="85"  r="4"   fill="#558B2F"/>
+        <circle cx="165" cy="145" r="3.5" fill="#2E7D32"/>
+        <circle cx="50"  cy="140" r="3"   fill="#2E7D32"/>
     </svg>
 
     <nav>

--- a/src/sejfa/newsflash/presentation/templates/base.html
+++ b/src/sejfa/newsflash/presentation/templates/base.html
@@ -6,28 +6,43 @@
     <title>{% block title %}News Flash{% endblock %}</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Architects+Daughter&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,700;1,400&family=Nunito:wght@300;400;600&display=swap" rel="stylesheet">
     <style>
         :root {
-            /* Napkin Sketch / Hand-Drawn Blueprint Theme */
-            --ink: #00008B;
-            --ink-75: rgba(0, 0, 139, 0.75);
-            --ink-40: rgba(0, 0, 139, 0.40);
-            --ink-20: rgba(0, 0, 139, 0.20);
-            --ink-10: rgba(0, 0, 139, 0.10);
-            --ink-06: rgba(0, 0, 139, 0.06);
-            --ink-03: rgba(0, 0, 139, 0.03);
-            --paper: #FFF9F0;
-            --paper-card: #FFFEF8;
-            --margin-red: rgba(210, 60, 60, 0.35);
+            /* Botanical Garden / Organic Zen Theme */
+            --forest: #2E7D32;
+            --forest-75: rgba(46, 125, 50, 0.75);
+            --forest-40: rgba(46, 125, 50, 0.40);
+            --forest-20: rgba(46, 125, 50, 0.20);
+            --forest-10: rgba(46, 125, 50, 0.10);
+            --forest-06: rgba(46, 125, 50, 0.06);
+            --forest-03: rgba(46, 125, 50, 0.03);
+            --sage-bg: #F1F8E9;
+            --parchment: #FAFFF5;
+            --parchment-card: #F7FBF0;
+            --terracotta: #D84315;
+            --terracotta-light: rgba(216, 67, 21, 0.12);
+            --fern: #558B2F;
+            --fern-light: rgba(85, 139, 47, 0.12);
         }
 
-        /* Hidden SVG filter for wobbly sketch lines */
-        .sketch-filter-defs {
-            position: absolute;
-            width: 0;
-            height: 0;
-            overflow: hidden;
+        /* ─── ANIMATIONS ─── */
+        @keyframes dapple-drift {
+            0%   { transform: translate(0%,   0%)   scale(1);    opacity: 0.55; }
+            33%  { transform: translate(3%,   2%)   scale(1.05); opacity: 0.40; }
+            66%  { transform: translate(-2%,  4%)   scale(0.97); opacity: 0.50; }
+            100% { transform: translate(0%,   0%)   scale(1);    opacity: 0.55; }
+        }
+
+        @keyframes leaf-sway {
+            0%,  100% { transform: rotate(0deg)    translateY(0);   }
+            30%        { transform: rotate(1.2deg)  translateY(-2px); }
+            70%        { transform: rotate(-0.8deg) translateY(1px);  }
+        }
+
+        @keyframes sprout {
+            0%   { transform: scale(0.95) translateY(6px); opacity: 0; }
+            100% { transform: scale(1)    translateY(0);   opacity: 1; }
         }
 
         * {
@@ -36,62 +51,42 @@
             box-sizing: border-box;
         }
 
-        /* Gentle pencil-tap animation */
-        @keyframes sketch-jitter {
-            0%, 100% { transform: rotate(0deg) translateY(0); }
-            25% { transform: rotate(0.4deg) translateY(-1px); }
-            75% { transform: rotate(-0.3deg) translateY(1px); }
-        }
-
-        /* Doodle pop-in */
-        @keyframes sketch-pop {
-            0% { transform: scale(0.97) rotate(-1deg); opacity: 0.7; }
-            60% { transform: scale(1.02) rotate(0.5deg); }
-            100% { transform: scale(1) rotate(0deg); opacity: 1; }
-        }
-
-        /* Underline draw animation */
-        @keyframes sketch-underline {
-            from { width: 0; }
-            to { width: 100%; }
-        }
-
         body {
             min-height: 100vh;
-            font-family: 'Architects Daughter', 'Comic Sans MS', cursive;
-            /* Lined notebook paper background */
-            background-color: var(--paper);
-            background-image:
-                /* Red margin line */
-                linear-gradient(90deg,
-                    transparent 62px,
-                    var(--margin-red) 62px,
-                    var(--margin-red) 64px,
-                    transparent 64px
-                ),
-                /* Horizontal ruled lines */
-                repeating-linear-gradient(
-                    transparent,
-                    transparent 27px,
-                    var(--ink-10) 27px,
-                    var(--ink-10) 28px
-                );
-            background-attachment: local;
-            color: var(--ink);
+            font-family: 'Nunito', 'Segoe UI', sans-serif;
+            background-color: var(--sage-bg);
+            color: var(--forest);
             position: relative;
             overflow-x: hidden;
             font-size: 16px;
             line-height: 1.7;
         }
 
-        /* Headings — hand-lettered style */
+        /* Dappled sunlight — light filtering through leaves */
+        body::before {
+            content: '';
+            position: fixed;
+            inset: 0;
+            pointer-events: none;
+            z-index: 0;
+            background-image:
+                radial-gradient(ellipse 180px 110px at 12%  8%,  rgba(255,255,200,0.30) 0%, transparent 70%),
+                radial-gradient(ellipse 220px 150px at 72%  4%,  rgba(255,255,180,0.24) 0%, transparent 70%),
+                radial-gradient(ellipse 130px 200px at 92% 38%,  rgba(255,255,210,0.22) 0%, transparent 70%),
+                radial-gradient(ellipse 200px 110px at 38% 62%,  rgba(255,255,200,0.18) 0%, transparent 70%),
+                radial-gradient(ellipse 160px 180px at  4% 78%,  rgba(255,255,190,0.20) 0%, transparent 70%),
+                radial-gradient(ellipse 110px 130px at 58% 88%,  rgba(255,255,200,0.16) 0%, transparent 70%);
+            animation: dapple-drift 22s ease-in-out infinite;
+        }
+
+        /* Headings — Playfair Display serif for editorial elegance */
         h1, h2, h3, h4, h5, h6 {
-            font-family: 'Architects Daughter', cursive;
-            font-weight: normal;
-            color: var(--ink);
+            font-family: 'Playfair Display', Georgia, serif;
+            font-weight: 700;
+            color: var(--forest);
             margin-bottom: 16px;
             line-height: 1.3;
-            letter-spacing: 0.5px;
+            letter-spacing: 0.3px;
             position: relative;
         }
 
@@ -100,15 +95,19 @@
         h3 { font-size: 19px; }
         h4 { font-size: 16px; }
 
-        /* Sketchy underline on headings */
+        /* Organic vine-gradient underline on headings */
         h1::after, h2::after {
             content: '';
             display: block;
-            height: 3px;
-            background: var(--ink-40);
-            border-radius: 2px 4px 1px 3px;
+            height: 2px;
+            background: linear-gradient(90deg, var(--fern), rgba(85,139,47,0.4) 60%, transparent);
+            border-radius: 2px;
             margin-top: 6px;
-            transform: rotate(-0.3deg);
+        }
+
+        /* List items use leaf nodes */
+        li::marker {
+            content: '🍃  ';
         }
 
         /* ─── HEADER ─── */
@@ -116,23 +115,19 @@
             position: relative;
             z-index: 10;
             padding: 18px 30px;
-            margin: 0;
-            border-bottom: 3px solid var(--ink);
-            /* Slightly wobbly border with box-shadow */
-            box-shadow: 0 3px 0 var(--ink-20), 0 5px 0 var(--ink-10);
-            background: var(--paper);
+            background: rgba(241, 248, 233, 0.94);
+            border-bottom: 1.5px solid var(--forest-20);
+            box-shadow: 0 4px 20px var(--forest-10), 0 2px 8px var(--forest-06);
+            backdrop-filter: blur(6px);
         }
 
-        /* Doodle arrow pointing right in header */
-        .header::before {
-            content: '';
+        .header::after {
+            content: '🌿';
             position: absolute;
-            bottom: -10px;
-            left: 80px;
-            width: 120px;
-            height: 8px;
-            background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 120 8'%3E%3Cpath d='M2 5 Q30 2 60 5 Q90 8 115 4 L110 1 M115 4 L110 7' stroke='%2300008B' stroke-opacity='0.35' stroke-width='1.5' fill='none' stroke-linecap='round'/%3E%3C/svg%3E");
-            background-repeat: no-repeat;
+            bottom: -13px;
+            right: 44px;
+            font-size: 18px;
+            z-index: 11;
             pointer-events: none;
         }
 
@@ -145,61 +140,43 @@
         }
 
         .header__logo {
-            font-family: 'Architects Daughter', cursive;
+            font-family: 'Playfair Display', Georgia, serif;
             font-size: 22px;
-            font-weight: normal;
-            color: var(--ink);
-            letter-spacing: 1px;
-            position: relative;
+            font-weight: 700;
+            color: var(--forest);
+            letter-spacing: 0.5px;
         }
 
-        /* Circled/underlined logo doodle */
         .header__logo::before {
-            content: '✏️ ';
+            content: '🌱 ';
             font-size: 18px;
         }
 
         .header__nav {
             display: flex;
-            gap: 16px;
+            gap: 14px;
             align-items: center;
         }
 
-        /* Nav links as hand-drawn buttons */
         .header__link {
-            font-family: 'Architects Daughter', cursive;
+            font-family: 'Nunito', sans-serif;
             font-size: 15px;
-            font-weight: normal;
-            color: var(--ink);
+            font-weight: 600;
+            color: var(--forest);
             text-decoration: none;
-            padding: 8px 20px;
-            border: 2px solid var(--ink);
-            /* Wobbly hand-drawn rectangle border */
-            border-radius: 255px 8px 225px 8px / 8px 225px 8px 255px;
-            transition: background 0.15s ease;
-            letter-spacing: 0.3px;
-            background: transparent;
-            position: relative;
-        }
-
-        .header__link::after {
-            content: '';
-            position: absolute;
-            inset: 3px;
-            border: 1px solid var(--ink-20);
-            border-radius: 255px 8px 225px 8px / 8px 225px 8px 255px;
-            pointer-events: none;
+            padding: 8px 22px;
+            border: 1.5px solid var(--forest-40);
+            border-radius: 20px;
+            background: var(--parchment);
+            box-shadow: 0 2px 8px var(--forest-10);
+            transition: all 0.2s ease;
         }
 
         .header__link:hover {
-            /* Light hatch fill on hover */
-            background-image: repeating-linear-gradient(
-                -45deg,
-                transparent,
-                transparent 4px,
-                var(--ink-06) 4px,
-                var(--ink-06) 5px
-            );
+            background: var(--fern-light);
+            border-color: var(--fern);
+            box-shadow: 0 4px 16px var(--forest-20);
+            transform: translateY(-1px);
         }
 
         /* ─── MAIN ─── */
@@ -218,9 +195,9 @@
             z-index: 10;
             padding: 20px 30px;
             margin: 40px 0 0;
-            border-top: 2px solid var(--ink-40);
-            box-shadow: 0 -2px 0 var(--ink-10);
-            background: var(--paper);
+            border-top: 1.5px solid var(--forest-20);
+            background: rgba(241, 248, 233, 0.94);
+            box-shadow: 0 -2px 12px var(--forest-06);
         }
 
         .footer__container {
@@ -229,137 +206,110 @@
         }
 
         .footer__text {
-            font-family: 'Architects Daughter', cursive;
+            font-family: 'Nunito', sans-serif;
             text-align: center;
-            color: var(--ink-75);
+            color: var(--forest-75);
             font-size: 14px;
         }
 
-        .footer__text::before {
-            content: '~ ';
-        }
-        .footer__text::after {
-            content: ' ~';
-        }
+        .footer__text::before { content: '🍃 '; }
+        .footer__text::after  { content: ' 🌿'; }
 
-        /* ─── GLOBAL CARD / PANEL ─── */
+        /* ─── GLOBAL CARD / PANEL — thick paper / cardstock feel ─── */
         .card, .panel, [class*="card"], [class*="panel"] {
-            background-color: var(--paper-card);
-            /* Cross-hatch fill */
-            background-image:
-                repeating-linear-gradient(
-                    -45deg,
-                    transparent 0px, transparent 9px,
-                    var(--ink-03) 9px, var(--ink-03) 10px
-                ),
-                repeating-linear-gradient(
-                    45deg,
-                    transparent 0px, transparent 9px,
-                    var(--ink-03) 9px, var(--ink-03) 10px
-                );
-            border: 2px solid var(--ink);
-            border-radius: 255px 8px 225px 8px / 8px 225px 8px 255px;
+            background: var(--parchment-card);
+            border: 1px solid var(--forest-20);
+            border-radius: 20px;
             padding: 24px;
             margin-bottom: 20px;
-            transition: transform 0.15s ease;
+            /* Soft, diffused multi-layer shadow to lift off the background */
+            box-shadow:
+                0 2px 4px  var(--forest-20),
+                0 6px 16px var(--forest-10),
+                0 12px 40px var(--forest-06);
+            transition: all 0.25s ease;
             position: relative;
         }
 
-        /* Inner sketch line for depth */
-        .card::after, .panel::after,
-        [class*="card"]::after, [class*="panel"]::after {
-            content: '';
-            position: absolute;
-            inset: 5px;
-            border: 1px solid var(--ink-20);
-            border-radius: 255px 8px 225px 8px / 8px 225px 8px 255px;
-            pointer-events: none;
-        }
-
+        /* Top vine accent */
         .card::before, .panel::before,
         [class*="card"]::before, [class*="panel"]::before {
+            content: '';
+            position: absolute;
+            top: 0;
+            left: 20px;
+            width: 48px;
+            height: 3px;
+            background: linear-gradient(90deg, var(--fern), transparent);
+            border-radius: 0 0 4px 4px;
+        }
+
+        .card::after, .panel::after,
+        [class*="card"]::after, [class*="panel"]::after {
             display: none;
         }
 
         .card:hover, .panel:hover,
         [class*="card"]:hover, [class*="panel"]:hover {
-            transform: translateY(-2px) rotate(0.3deg);
+            transform: translateY(-3px);
+            box-shadow:
+                0 4px 8px   var(--forest-20),
+                0 12px 28px var(--forest-20),
+                0 24px 56px var(--forest-10);
         }
 
         /* ─── BUTTONS ─── */
         button, .button, input[type="submit"] {
-            font-family: 'Architects Daughter', cursive;
-            font-weight: normal;
-            background: transparent;
-            background-image: repeating-linear-gradient(
-                -45deg,
-                transparent 0px, transparent 5px,
-                var(--ink-06) 5px, var(--ink-06) 6px
-            );
-            color: var(--ink);
-            border: 2px solid var(--ink);
+            font-family: 'Nunito', sans-serif;
+            font-weight: 600;
+            background: var(--forest);
+            color: #FAFFF5;
+            border: none;
             padding: 10px 26px;
-            border-radius: 255px 8px 225px 8px / 8px 225px 8px 255px;
+            border-radius: 20px;
             cursor: pointer;
             font-size: 15px;
-            transition: all 0.15s ease;
-            letter-spacing: 0.5px;
-            position: relative;
-        }
-
-        button::after, .button::after, input[type="submit"]::after {
-            content: '';
-            position: absolute;
-            inset: 4px;
-            border: 1px solid var(--ink-20);
-            border-radius: 255px 8px 225px 8px / 8px 225px 8px 255px;
-            pointer-events: none;
+            transition: all 0.2s ease;
+            letter-spacing: 0.3px;
+            box-shadow: 0 3px 12px var(--forest-40);
         }
 
         button:hover, .button:hover, input[type="submit"]:hover {
-            background-image: repeating-linear-gradient(
-                -45deg,
-                transparent 0px, transparent 4px,
-                var(--ink-10) 4px, var(--ink-10) 5px
-            ),
-            repeating-linear-gradient(
-                45deg,
-                transparent 0px, transparent 4px,
-                var(--ink-10) 4px, var(--ink-10) 5px
-            );
-            transform: translateY(-1px) rotate(0.5deg);
+            background: var(--fern);
+            box-shadow: 0 6px 22px var(--forest-40);
+            transform: translateY(-2px);
         }
 
         button:active, .button:active, input[type="submit"]:active {
-            transform: translateY(1px) rotate(-0.3deg);
+            transform: translateY(1px);
+            box-shadow: 0 2px 6px var(--forest-20);
         }
 
         button:focus, .button:focus, input[type="submit"]:focus {
-            outline: 2px dashed var(--ink);
+            outline: 2px solid var(--fern);
             outline-offset: 4px;
         }
 
         /* ─── INPUTS ─── */
         input, textarea, select {
-            background: var(--paper);
-            border: 2px solid var(--ink-75);
-            border-radius: 4px 6px 4px 5px / 5px 4px 6px 4px;
-            color: var(--ink);
+            background: var(--parchment);
+            border: 1.5px solid var(--forest-40);
+            border-radius: 12px;
+            color: var(--forest);
             padding: 10px 14px;
-            font-family: 'Architects Daughter', cursive;
+            font-family: 'Nunito', sans-serif;
             font-size: 15px;
-            transition: border-color 0.15s ease;
+            transition: all 0.2s ease;
         }
 
         input:focus, textarea:focus, select:focus {
             outline: none;
-            border-color: var(--ink);
-            border-width: 2px;
-            box-shadow: 3px 3px 0 var(--ink-20);
+            border-color: var(--fern);
+            box-shadow: 0 0 0 3px var(--fern-light);
         }
 
         input::placeholder, textarea::placeholder {
-            color: var(--ink-40);
+            color: var(--forest-40);
             font-style: italic;
         }
 
@@ -372,116 +322,92 @@
         .hero__container {
             max-width: 820px;
             margin: 0 auto;
-            background-color: var(--paper-card);
-            background-image:
-                repeating-linear-gradient(
-                    -45deg,
-                    transparent 0px, transparent 9px,
-                    var(--ink-03) 9px, var(--ink-03) 10px
-                );
-            border: 2px solid var(--ink);
-            border-radius: 255px 12px 225px 12px / 12px 225px 12px 255px;
+            background: var(--parchment-card);
+            border: 1px solid var(--forest-20);
+            border-radius: 28px;
             padding: 50px 44px;
             position: relative;
-            animation: sketch-jitter 6s ease-in-out infinite;
+            box-shadow:
+                0 4px 8px   var(--forest-20),
+                0 10px 32px var(--forest-10),
+                0 20px 60px var(--forest-06);
+            animation: leaf-sway 9s ease-in-out infinite;
         }
 
-        /* Corner doodle marks */
         .hero__container::before {
-            content: '✕';
+            content: '🍃';
             position: absolute;
-            top: 12px;
-            left: 18px;
-            font-size: 12px;
-            color: var(--ink-40);
-            line-height: 1;
+            top: 14px;
+            left: 20px;
+            font-size: 20px;
+            opacity: 0.45;
+            transform: rotate(-18deg);
         }
 
         .hero__container::after {
-            content: '✕';
+            content: '🌿';
             position: absolute;
-            bottom: 12px;
-            right: 18px;
-            font-size: 12px;
-            color: var(--ink-40);
-            line-height: 1;
+            bottom: 14px;
+            right: 20px;
+            font-size: 20px;
+            opacity: 0.45;
+            transform: rotate(14deg);
         }
 
         .hero__heading {
             font-size: 42px;
             margin-bottom: 18px;
-            letter-spacing: 1px;
-            color: var(--ink);
-            position: relative;
+            color: var(--forest);
+            font-family: 'Playfair Display', Georgia, serif;
         }
 
-        /* Rough underline on hero heading */
         .hero__heading::after {
             content: '';
             display: block;
-            height: 3px;
-            background: var(--ink-75);
+            height: 2px;
+            background: linear-gradient(90deg, transparent, var(--fern), rgba(85,139,47,0.3), transparent);
             margin: 8px auto 0;
             width: 60%;
-            border-radius: 2px 4px 1px 3px;
-            transform: rotate(-0.5deg);
+            border-radius: 2px;
         }
 
         .hero__subtitle {
             font-size: 17px;
-            color: var(--ink-75);
+            color: var(--forest-75);
             margin-bottom: 34px;
             line-height: 1.8;
             font-style: italic;
+            font-family: 'Playfair Display', Georgia, serif;
         }
 
         .hero__button {
             display: inline-block;
-            font-family: 'Architects Daughter', cursive;
-            font-weight: normal;
-            background-image: repeating-linear-gradient(
-                -45deg,
-                transparent 0px, transparent 5px,
-                var(--ink-06) 5px, var(--ink-06) 6px
-            );
-            color: var(--ink);
-            border: 2px solid var(--ink);
+            font-family: 'Nunito', sans-serif;
+            font-weight: 600;
+            background: var(--forest);
+            color: #FAFFF5;
+            border: none;
             padding: 14px 42px;
             text-decoration: none;
             font-size: 17px;
-            border-radius: 255px 10px 225px 10px / 10px 225px 10px 255px;
-            transition: all 0.15s ease;
-            letter-spacing: 0.5px;
-            position: relative;
+            border-radius: 22px;
+            transition: all 0.2s ease;
+            letter-spacing: 0.3px;
+            box-shadow: 0 4px 18px var(--forest-40);
         }
 
-        .hero__button::after {
-            content: ' →';
-            font-style: normal;
-        }
+        .hero__button::after { content: ' 🌱'; }
 
         .hero__button:hover {
-            background-image: repeating-linear-gradient(
-                -45deg,
-                transparent 0px, transparent 4px,
-                var(--ink-10) 4px, var(--ink-10) 5px
-            ),
-            repeating-linear-gradient(
-                45deg,
-                transparent 0px, transparent 4px,
-                var(--ink-10) 4px, var(--ink-10) 5px
-            );
-            transform: translateY(-2px) rotate(0.5deg);
+            background: var(--fern);
+            box-shadow: 0 8px 30px var(--forest-40);
+            transform: translateY(-3px);
         }
 
-        .hero__button:active {
-            transform: translateY(1px) rotate(-0.3deg);
-        }
+        .hero__button:active { transform: translateY(1px); }
 
         /* ─── FEATURES SECTION ─── */
-        .features {
-            padding: 40px 0;
-        }
+        .features { padding: 40px 0; }
 
         .features__container {
             display: grid;
@@ -492,66 +418,64 @@
         }
 
         .features__card {
-            background-color: var(--paper-card);
-            background-image:
-                repeating-linear-gradient(
-                    -45deg,
-                    transparent 0px, transparent 8px,
-                    var(--ink-03) 8px, var(--ink-03) 9px
-                );
-            border: 2px solid var(--ink);
-            border-radius: 255px 8px 225px 8px / 8px 225px 8px 255px;
-            padding: 28px 26px;
+            background: var(--parchment-card);
+            border: 1px solid var(--forest-20);
+            border-radius: 20px;
+            padding: 32px 26px 28px;
             position: relative;
-            transition: transform 0.15s ease;
+            box-shadow:
+                0 2px 4px   var(--forest-20),
+                0 6px 20px  var(--forest-10),
+                0 12px 40px var(--forest-06);
+            transition: all 0.25s ease;
+            animation: sprout 0.5s ease-out both;
         }
 
-        /* Cards slightly skewed for that "doodled on paper" feel */
-        .features__card:nth-child(1) { transform: rotate(-0.8deg); }
-        .features__card:nth-child(2) { transform: rotate(0.5deg); }
-        .features__card:nth-child(3) { transform: rotate(-0.4deg); }
+        .features__card:nth-child(1) { animation-delay: 0.1s; }
+        .features__card:nth-child(2) { animation-delay: 0.2s; }
+        .features__card:nth-child(3) { animation-delay: 0.3s; }
 
-        .features__card:nth-child(1):hover { transform: rotate(-0.4deg) translateY(-3px); }
-        .features__card:nth-child(2):hover { transform: rotate(0.8deg) translateY(-3px); }
-        .features__card:nth-child(3):hover { transform: rotate(-0.8deg) translateY(-3px); }
-
-        /* Inner inset line */
-        .features__card::after {
-            content: '';
-            position: absolute;
-            inset: 5px;
-            border: 1px solid var(--ink-20);
-            border-radius: 255px 8px 225px 8px / 8px 225px 8px 255px;
-            pointer-events: none;
-        }
-
+        /* Leaf node at top of each card */
         .features__card::before {
-            display: none;
+            content: '🍃';
+            position: absolute;
+            top: -12px;
+            left: 50%;
+            transform: translateX(-50%);
+            font-size: 22px;
+        }
+
+        .features__card::after { display: none; }
+
+        .features__card:hover {
+            transform: translateY(-4px);
+            box-shadow:
+                0 4px 10px  var(--forest-20),
+                0 14px 36px var(--forest-20),
+                0 28px 64px var(--forest-10);
         }
 
         .features__title {
             font-size: 18px;
-            font-weight: normal;
-            font-family: 'Architects Daughter', cursive;
+            font-weight: 700;
+            font-family: 'Playfair Display', Georgia, serif;
             margin-bottom: 12px;
-            color: var(--ink);
-            letter-spacing: 0.5px;
-            border-bottom: 1px solid var(--ink-20);
-            padding-bottom: 8px;
+            margin-top: 6px;
+            color: var(--forest);
+            letter-spacing: 0.3px;
+            border-bottom: 1px solid var(--forest-10);
+            padding-bottom: 10px;
         }
 
         .features__text {
             font-size: 15px;
-            font-family: 'Architects Daughter', cursive;
-            color: var(--ink-75);
+            font-family: 'Nunito', sans-serif;
+            color: var(--forest-75);
             line-height: 1.8;
-            font-style: italic;
         }
 
         /* ─── SUBSCRIBE SECTION ─── */
-        .subscribe {
-            padding: 40px 0;
-        }
+        .subscribe { padding: 40px 0; }
 
         .subscribe__container {
             max-width: 600px;
@@ -562,68 +486,50 @@
             font-size: 28px;
             margin-bottom: 10px;
             text-align: center;
-            color: var(--ink);
+            color: var(--forest);
+            font-family: 'Playfair Display', Georgia, serif;
         }
 
         .subscribe__subtitle {
             font-size: 15px;
-            font-family: 'Architects Daughter', cursive;
-            color: var(--ink-75);
+            font-family: 'Playfair Display', Georgia, serif;
+            font-style: italic;
+            color: var(--forest-75);
             margin-bottom: 28px;
             text-align: center;
-            font-style: italic;
         }
 
         .subscribe__form {
-            background-color: var(--paper-card);
-            background-image:
-                repeating-linear-gradient(
-                    -45deg,
-                    transparent 0px, transparent 9px,
-                    var(--ink-03) 9px, var(--ink-03) 10px
-                );
-            border: 2px solid var(--ink);
-            border-radius: 255px 12px 225px 12px / 12px 225px 12px 255px;
+            background: var(--parchment-card);
+            border: 1px solid var(--forest-20);
+            border-radius: 24px;
             padding: 36px 32px;
             position: relative;
+            box-shadow:
+                0 4px 8px   var(--forest-20),
+                0 10px 30px var(--forest-10),
+                0 20px 56px var(--forest-06);
         }
 
-        .subscribe__form::after {
-            content: '';
-            position: absolute;
-            inset: 6px;
-            border: 1px solid var(--ink-20);
-            border-radius: 255px 12px 225px 12px / 12px 225px 12px 255px;
-            pointer-events: none;
-        }
-
-        .form__group {
-            margin-bottom: 22px;
-        }
+        .form__group { margin-bottom: 22px; }
 
         .form__label {
             display: block;
-            font-family: 'Architects Daughter', cursive;
+            font-family: 'Nunito', sans-serif;
             font-size: 14px;
-            font-weight: normal;
-            color: var(--ink);
+            font-weight: 600;
+            color: var(--forest);
             margin-bottom: 8px;
-            letter-spacing: 0.5px;
+            letter-spacing: 0.3px;
         }
 
-        /* Asterisk hint label */
-        .form__label::before {
-            content: '> ';
-            color: var(--ink-40);
-        }
+        .form__label::before { content: '🍃 '; }
 
-        .form__input {
-            width: 100%;
-        }
+        .form__input { width: 100%; }
 
         .form__input--error {
-            border-color: var(--ink);
-            border-style: dashed;
+            border-color: var(--terracotta);
+            box-shadow: 0 0 0 3px var(--terracotta-light);
         }
 
         .form__button {
@@ -637,147 +543,115 @@
         .error-banner, .flash-message {
             padding: 16px 22px;
             margin-bottom: 20px;
-            border: 2px solid var(--ink);
-            border-radius: 4px 8px 4px 6px / 6px 4px 8px 4px;
-            font-family: 'Architects Daughter', cursive;
+            border-radius: 16px;
+            font-family: 'Nunito', sans-serif;
             font-size: 15px;
-            letter-spacing: 0.3px;
+            letter-spacing: 0.2px;
             position: relative;
-            animation: sketch-pop 0.3s ease-out;
-            background-color: var(--paper-card);
-            background-image: repeating-linear-gradient(
-                -45deg,
-                transparent 0px, transparent 6px,
-                var(--ink-06) 6px, var(--ink-06) 7px
-            );
+            animation: sprout 0.3s ease-out;
         }
 
         .error-banner, .flash-message.error {
-            border-style: dashed;
+            background: var(--terracotta-light);
+            border: 1px solid var(--terracotta);
+            color: var(--terracotta);
         }
 
         .flash-message.success {
-            border-style: solid;
+            background: var(--fern-light);
+            border: 1px solid var(--fern);
+            color: var(--fern);
         }
 
-        .error-banner::before, .flash-message.error::before {
-            content: '⚠ ';
-            font-weight: bold;
-        }
-
-        .flash-message.success::before {
-            content: '✓ ';
-            font-weight: bold;
-        }
+        .error-banner::before, .flash-message.error::before { content: '🌵 '; }
+        .flash-message.success::before { content: '🌱 '; }
 
         /* ─── THANK YOU SECTION ─── */
-        .thank-you {
-            padding: 40px 0;
-        }
+        .thank-you { padding: 40px 0; }
 
         .thank-you__container {
             max-width: 720px;
             margin: 0 auto;
             text-align: center;
-            background-color: var(--paper-card);
-            background-image:
-                repeating-linear-gradient(
-                    -45deg,
-                    transparent 0px, transparent 9px,
-                    var(--ink-03) 9px, var(--ink-03) 10px
-                );
-            border: 2px solid var(--ink);
-            border-radius: 255px 12px 225px 12px / 12px 225px 12px 255px;
+            background: var(--parchment-card);
+            border: 1px solid var(--forest-20);
+            border-radius: 28px;
             padding: 50px 44px;
             position: relative;
-            animation: sketch-jitter 7s ease-in-out infinite;
+            box-shadow:
+                0 4px 8px   var(--forest-20),
+                0 10px 30px var(--forest-10),
+                0 20px 56px var(--forest-06);
+            animation: leaf-sway 10s ease-in-out infinite;
         }
 
         .thank-you__container::before {
-            content: '★';
+            content: '🌿';
             position: absolute;
-            top: 14px;
-            right: 20px;
-            font-size: 16px;
-            color: var(--ink-20);
+            top: 16px;
+            right: 22px;
+            font-size: 22px;
+            opacity: 0.45;
         }
 
-        .thank-you__container::after {
-            content: '';
-            position: absolute;
-            inset: 6px;
-            border: 1px solid var(--ink-20);
-            border-radius: 255px 12px 225px 12px / 12px 225px 12px 255px;
-            pointer-events: none;
-        }
+        .thank-you__container::after { display: none; }
 
         .thank-you__heading {
             font-size: 30px;
             margin-bottom: 22px;
-            color: var(--ink);
+            color: var(--forest);
+            font-family: 'Playfair Display', Georgia, serif;
         }
 
         .thank-you__text {
             font-size: 16px;
-            font-family: 'Architects Daughter', cursive;
-            color: var(--ink-75);
+            font-family: 'Playfair Display', Georgia, serif;
+            font-style: italic;
+            color: var(--forest-75);
             margin-bottom: 14px;
             line-height: 1.8;
-            font-style: italic;
         }
 
         .thank-you__text strong {
-            color: var(--ink);
+            color: var(--forest);
             font-style: normal;
             text-decoration: underline;
             text-decoration-style: wavy;
+            text-decoration-color: var(--fern);
             text-underline-offset: 3px;
         }
 
         .thank-you__button {
             display: inline-block;
             margin-top: 28px;
-            font-family: 'Architects Daughter', cursive;
-            font-weight: normal;
-            background-image: repeating-linear-gradient(
-                -45deg,
-                transparent 0px, transparent 5px,
-                var(--ink-06) 5px, var(--ink-06) 6px
-            );
-            color: var(--ink);
-            border: 2px solid var(--ink);
+            font-family: 'Nunito', sans-serif;
+            font-weight: 600;
+            background: var(--forest);
+            color: #FAFFF5;
+            border: none;
             padding: 14px 40px;
             text-decoration: none;
             font-size: 16px;
-            border-radius: 255px 10px 225px 10px / 10px 225px 10px 255px;
-            transition: all 0.15s ease;
+            border-radius: 22px;
+            transition: all 0.2s ease;
+            box-shadow: 0 4px 16px var(--forest-40);
         }
 
-        .thank-you__button::before {
-            content: '← ';
-        }
+        .thank-you__button::before { content: '← '; }
 
         .thank-you__button:hover {
-            background-image: repeating-linear-gradient(
-                -45deg,
-                transparent 0px, transparent 4px,
-                var(--ink-10) 4px, var(--ink-10) 5px
-            ),
-            repeating-linear-gradient(
-                45deg,
-                transparent 0px, transparent 4px,
-                var(--ink-10) 4px, var(--ink-10) 5px
-            );
-            transform: translateY(-2px) rotate(-0.5deg);
+            background: var(--fern);
+            box-shadow: 0 8px 28px var(--forest-40);
+            transform: translateY(-2px);
         }
 
         /* ─── CODE BLOCKS ─── */
         code, pre, .data, [class*="code"], [class*="data"] {
             font-family: 'Courier New', monospace;
-            color: var(--ink);
-            background: var(--paper-card);
-            border: 1px solid var(--ink-40);
-            border-radius: 2px 4px 2px 3px;
+            color: var(--forest);
+            background: var(--parchment);
+            border: 1px solid var(--forest-20);
+            border-radius: 10px;
             padding: 8px 14px;
             font-size: 13px;
         }
@@ -785,14 +659,23 @@
     {% block extra_css %}{% endblock %}
 </head>
 <body>
-    <!-- Hidden SVG defs for potential sketch filters -->
-    <svg class="sketch-filter-defs" aria-hidden="true">
-        <defs>
-            <filter id="sketchy-border" x="-5%" y="-5%" width="110%" height="110%">
-                <feTurbulence type="turbulence" baseFrequency="0.04" numOctaves="4" seed="5" result="noise"/>
-                <feDisplacementMap in="SourceGraphic" in2="noise" scale="2" xChannelSelector="R" yChannelSelector="G"/>
-            </filter>
-        </defs>
+    <!-- Decorative organic SVG vine — bezier curves as stems/vines -->
+    <svg aria-hidden="true" style="position:fixed;bottom:0;left:0;width:340px;height:320px;pointer-events:none;z-index:0;opacity:0.09;" viewBox="0 0 340 320" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path d="M20 320 C 40 240, 80 220, 60 160 C 40 100, 100 80, 90 20" stroke="#2E7D32" stroke-width="2.5" stroke-linecap="round"/>
+        <path d="M60 160 C 100 150, 130 120, 160 100" stroke="#2E7D32" stroke-width="1.8" stroke-linecap="round"/>
+        <path d="M90 220 C 130 210, 160 190, 180 160" stroke="#558B2F" stroke-width="1.5" stroke-linecap="round"/>
+        <circle cx="160" cy="100" r="4" fill="#558B2F"/>
+        <circle cx="180" cy="160" r="3.5" fill="#2E7D32"/>
+        <circle cx="60"  cy="160" r="3"   fill="#2E7D32"/>
+    </svg>
+
+    <svg aria-hidden="true" style="position:fixed;top:0;right:0;width:280px;height:260px;pointer-events:none;z-index:0;opacity:0.08;" viewBox="0 0 280 260" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path d="M280 0 C 240 40, 200 30, 220 90 C 240 150, 180 170, 190 240" stroke="#2E7D32" stroke-width="2.5" stroke-linecap="round"/>
+        <path d="M220 90 C 180 80, 150 100, 120 80" stroke="#558B2F" stroke-width="1.8" stroke-linecap="round"/>
+        <path d="M190 180 C 160 170, 130 185, 100 170" stroke="#558B2F" stroke-width="1.5" stroke-linecap="round"/>
+        <circle cx="120" cy="80"  r="4"   fill="#558B2F"/>
+        <circle cx="100" cy="170" r="3.5" fill="#2E7D32"/>
+        <circle cx="220" cy="90"  r="3"   fill="#2E7D32"/>
     </svg>
 
     <header class="header">


### PR DESCRIPTION
## Summary
- Transform the app UI to a lush **Botanical Garden / Organic Zen** aesthetic — the "Wow factor" theme that feels like a digital greenhouse / living terrarium
- Applies to both newsflash and expense tracker base templates

## Changes
- **Background:** Pale sage green (#F1F8E9) with animated dappled sunlight overlay (6 radial gradients drifting on a 22s cycle to simulate light filtering through leaves)
- **Colors:** Deep forest green (#2E7D32) for text, earthy terracotta (#D84315) for alerts/errors, fern green (#558B2F) for success states
- **Fonts:** Playfair Display (serif) for all headers — elegant editorial look; Nunito (rounded sans-serif) for body/data
- **Cards & Panels:** Paper/cardstock feel with soft multi-layer diffused drop shadows, 16–28px border-radius (no sharp digital edges)
- **Layout:** Decorative SVG bezier curves as vine/stem ornaments; leaf 🍃 icons as node markers replacing standard dots; `li::marker` uses 🍃
- **Animations:** `leaf-sway` on hero/thank-you containers, `sprout` pop-in on feature cards, `dapple-drift` on background light

## Test plan
- [x] All 383 tests pass (`pytest -xvs`)
- [x] Linting clean (`ruff check .`)
- [x] Both Flask templates updated (newsflash + expense tracker)
- [x] Theme covers background, colors, fonts, cards, layout nodes as specified in ticket

🤖 Generated with [Claude Code](https://claude.com/claude-code)